### PR TITLE
Fix converting float to string for portability

### DIFF
--- a/lib/Data/Util.xs
+++ b/lib/Data/Util.xs
@@ -102,9 +102,9 @@ S_nv_is_integer(pTHX_ NV const nv) {
         return TRUE;
     }
     else {
-        char buf[64];  /* Must fit sprintf/Gconvert of longest NV */
+        char buf[128];  /* Must fit sprintf of longest NV(__float128) */
         char* p;
-        (void)Gconvert(nv, NV_DIG, 0, buf);
+        (void)my_snprintf(buf, sizeof(buf), "%" NVff, nv);
         p = &buf[0];
 
         /* -?[0-9]+ */


### PR DESCRIPTION
If 'usequadmath' is enabled, then NV type is __float128.
However Gconvert cannot convert 128bit floating point number,
because it uses sprintf. So we use my_snprintf, it uses
quadmath_snprintf when 'usequadmath' is enabled.

Some tests are failed with `usequadmath` Perl by this issue.